### PR TITLE
sourceMap, excludes, mimosa interface, placeholder updates

### DIFF
--- a/mimosa-config.coffee
+++ b/mimosa-config.coffee
@@ -7,3 +7,6 @@ exports.config =
   jshint:
     rules:
       node: true
+  to5:
+    options:
+      sourceMap: null

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ export var defaults = () => { return {
   	extensions: ['js', 'es6'],
 
   	// Exclude files regex
-    exclude: null,
+    exclude: [],
 
     // Compiler options
     options: {
@@ -77,20 +77,25 @@ export var defaults = () => { return {
   }
 }};
 
-export function placeholder() {
-  return `
-  \t
-    rename:                     # Configuration for non-require minification/compression via
-                                # uglify using the --minify flag.
-      map: []                   # List of string paths and regexes to match files to exclude
-                                # when running minification. Any path with ".min." in its name,
-                                # like jquery.min.js, is assumed to already be minified and is
-                                # ignored by default. Paths can be relative to the
-                                # watch.compiledDir, or absolute.  Paths are to compiled files,
-                                # so '.js' rather than '.coffee'
-  `;
-}
+export function validate(config, validators) {
+  let errors = [];
 
-export function validate() {
-  return [];
+  if (validators.ifExistsIsObject(errors, "to5 config", config.to5)) {
+
+    if ( validators.isArrayOfStringsMustExist( errors, "to5.extensions", config.to5.extensions ) ) {
+      if (config.to5.extensions.length === 0) {
+        errors.push( "to5.extensions cannot be an empty array");
+      }
+    }
+
+    validators.ifExistsIsObject(errors, "to5.options", config.to5.options);
+    validators.ifExistsIsArray(errors, "to5.exclude", config.to5.exclude);
+  }
+
+  // if user has not provided their own version, use local 6to5
+  if ( !errors.length && !config.to5.lib ) {
+    config.to5.lib = require( "6to5" );
+  }
+
+  return errors;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export { compile, extensions } from './plugin';
-export { defaults, placeholder, validate } from './config';
+export { defaults, validate } from './config';
 
 export var name = '6to5';
 export var compilerType = 'javascript';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { compile, getExtensions } from './plugin';
+export { compile, extensions } from './plugin';
 export { defaults, placeholder, validate } from './config';
 
 export var name = '6to5';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { compile, extensions } from './plugin';
+export { compile, getExtensions } from './plugin';
 export { defaults, placeholder, validate } from './config';
 
 export var name = '6to5';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,26 +1,17 @@
 let path = require('path');
 let logger = null;
-let compiler = null;
-
-let typeIsArray = Array.isArray || (value) => ({}.toString.call(value) === '[object Array]');
 
 function _compile(config, file, cb) {
-  if (compiler === null)
-    compiler = require('6to5');
-
-  let exclude = config.exclude
-  if (!typeIsArray(exclude))
-    exclude = [exclude];
   //console.log options
 
-  if (isExcluded(exclude, file.inputFileName)) {
+  if (isExcluded(config.exclude, file.inputFileName)) {
     logger.debug(`skipping 6to5 transpiling for [[ ${file.inputFileName} ]], file is excluded`);
     return cb();
   }
 
   if (file.isVendor) {
     logger.debug(`skipping 6to5 transpiling for [[ ${file.inputFileName} ]], is vendor file`);
-    //console.log "skipping es6Modules transpiling for [[ #{file.inputFileName} ]], file is vendor"
+    //console.log "skipping 6to5 transpiling for [[ #{file.inputFileName} ]], is vendor file"
     return cb();
   }
 
@@ -31,7 +22,7 @@ function _compile(config, file, cb) {
         ast: false
       });
 
-      let result = compiler.transform(file.inputFileText, fOpts);
+      let result = config.lib.transform(file.inputFileText, fOpts);
 
       // if source map is inline, need to leave sourceMap null to avoid
       // appending extra source map comment in mimosa core
@@ -57,7 +48,6 @@ function _compile(config, file, cb) {
     cb();
   }
 }
-
 
 function isExcluded(filters, name) {
   return filters.some((filter) => {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -72,7 +72,7 @@ function extend(object, ...args) {
   return object;
 }
 
-export function getExtensions(conf) {
+export function extensions(conf) {
   return conf.to5.extensions;
 }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,12 +14,12 @@ function _compile(config, file, cb) {
   //console.log options
 
   if (isExcluded(exclude, file.inputFileName)) {
-    logger.debug(`skipping es6Modules transpiling for [[ ${file.inputFileName} ]], file is excluded via regex`);
+    logger.debug(`skipping 6to5 transpiling for [[ ${file.inputFileName} ]], file is excluded`);
     return cb();
   }
 
   if (file.isVendor) {
-    logger.debug(`skipping es6Modules transpiling for [[ ${file.inputFileName} ]], file is vendor`);
+    logger.debug(`skipping 6to5 transpiling for [[ ${file.inputFileName} ]], is vendor file`);
     //console.log "skipping es6Modules transpiling for [[ #{file.inputFileName} ]], file is vendor"
     return cb();
   }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -72,7 +72,7 @@ function extend(object, ...args) {
   return object;
 }
 
-export function extensions(conf) {
+export function getExtensions(conf) {
   return conf.to5.extensions;
 }
 


### PR DESCRIPTION
Group of updates here:

- function needs to be `getExtensions` for mimosa core to use.  I like `extensions` better and may add that and deprecate `getExtensions` down the road.
- fixed some issues with source maps being double created when source map was inlined
- turned off generation of source maps when library was building itself
- normalized exclude to an array in the defaults alleviating the need to check for and deal with it possibly not being an array in the code
- added some validation, not validating the options being sent to 6to5, could be added later
- removed placeholder.  The pieces of mimosa core that utilize that are likely to be nuked in the very near term.  It isn't necessary as it is, so just removed it.

Let me know if you have any issues here.  I didn't want to update/create docs until I ran this by ya.